### PR TITLE
Trying fix for phpunit on travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 
 script:
   - cd $TRAVIS_BUILD_DIR && vendor/bin/phpcs -p --standard=PSR2 --extensions=php --ignore=*/Migrations/* ./src
-  - cd $TRAVIS_BUILD_DIR && sudo php bin/phpunit
+  - cd $TRAVIS_BUILD_DIR && /usr/bin/env php bin/phpunit
   - cd $TRAVIS_BUILD_DIR/acceptance-tests && vendor/bin/codecept run --debug --env=travis
   
 after_failure:


### PR DESCRIPTION
:exclamation: Do not merge! Only testing

`bin/phpunit` does not have execute permissions  (`-rw-rw-r--`).
Trying this as an alternative to `chmod +x`.

Assuming TravisCI does not have `php` accessible via `$PATH` directories, so `php bin/phpunit` did not workerd.